### PR TITLE
Ads server's url has changed

### DIFF
--- a/src/test/java/net/codjo/ads/AdsTest.java
+++ b/src/test/java/net/codjo/ads/AdsTest.java
@@ -4,8 +4,8 @@ package net.codjo.ads;
  */
 public interface AdsTest {
 
-    String LDAP_URL = "ldap://ads_bv_1.tagi-d.tagi-de.net:40389";
-    String SSL_URL = "ldap://ads_bv_1.tagi-d.tagi-de.net:40636";
+    String LDAP_URL = "ldap://AFYTD201.tagi2-d.net:40389";
+    String SSL_URL = "ldap://AFYTD201.tagi2-d.net:40636";
 
     String ADSBV_JNLP_URL = "http://vildapbv.vi.intradit.net/ADSBV/adsbvgui.jnlp";
 


### PR DESCRIPTION
## Context

The ads server has moved.
## Description

We changed the `LDAP_URL` and `SSL_URL` values to the new url.
